### PR TITLE
update async timeout to 180s

### DIFF
--- a/any_parser/__init__.py
+++ b/any_parser/__init__.py
@@ -4,4 +4,4 @@ from any_parser.any_parser import AnyParser
 
 __all__ = ["AnyParser"]
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"

--- a/any_parser/any_parser.py
+++ b/any_parser/any_parser.py
@@ -24,7 +24,7 @@ from any_parser.utils import validate_file_inputs
 
 PUBLIC_SHARED_BASE_URL = "https://public-api.cambioml.com"
 PUBLIC_BATCH_BASE_URL = "http://batch-api.cambioml.com"
-TIMEOUT = 60
+TIMEOUT = 180
 
 
 def handle_file_processing(func):
@@ -399,7 +399,7 @@ class AnyParser:
         self,
         file_id: str,
         sync: bool = True,
-        sync_timeout: int = 60,
+        sync_timeout: int = 180,
         sync_interval: int = 5,
     ) -> str:
         """Fetches extraction results asynchronously.
@@ -409,7 +409,7 @@ class AnyParser:
             sync (bool, optional): Whether to wait for the results
                 synchronously.
             sync_timeout (int, optional): Maximum time to wait for results in
-                seconds. Defaults to 60.
+                seconds. Defaults to 180.
             sync_interval (int, optional): Time interval between polling
                 attempts in seconds. Defaults to 5.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "any-parser"
-version = "0.0.23"
+version = "0.0.24"
 description = "Parser for all."
 authors = ["CambioML <wanwanaiai45@gmail.com>"]
 maintainers = ["Rachel Hu <goldpiggy@berkeley.edu>"]


### PR DESCRIPTION
### **User description**
## Description
<!-- Provide a brief description of the changes introduced by this PR -->

## Related Issue
<!-- Link to the related issue (if applicable) using #issue_number -->

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any additional notes or context about the PR here -->


___

### **PR Type**
Enhancement


___

### **Description**
- Increase default TIMEOUT to 180 seconds

- Extend default sync_timeout to 180 seconds

- Bump package version to 0.0.24


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Bump package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

any_parser/__init__.py

- Updated `__version__` from "0.0.23" to "0.0.24"


</details>


  </td>
  <td><a href="https://github.com/CambioML/any-parser/pull/85/files#diff-b3eae8a05347cb37971af2d6dc2250e2374c5ba64ad5c758a7bc4c8f14f8a0c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>any_parser.py</strong><dd><code>Increase default timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

any_parser/any_parser.py

<li>Increased <code>TIMEOUT</code> constant to 180 seconds<br> <li> Updated default <code>sync_timeout</code> parameter to 180 seconds<br> <li> Adjusted docstring default timeout values accordingly


</details>


  </td>
  <td><a href="https://github.com/CambioML/any-parser/pull/85/files#diff-b580101abf5c2c14a05ba9e6a763e462c65136ba8e884488ddcd93561600346d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update project version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped project `version` to "0.0.24"


</details>


  </td>
  <td><a href="https://github.com/CambioML/any-parser/pull/85/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>